### PR TITLE
feat: make transpose_arbitrary_grouped public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,7 @@ pub use rotate180::{
     rotate180_rgb16, rotate180_rgb_f32, rotate180_rgba, rotate180_rgba16, rotate180_rgba_f32,
 };
 pub use transpose_arbitrary::transpose_arbitrary;
+pub use transpose_arbitrary_group::transpose_arbitrary_grouped;
 pub use unsigned_16::{
     transpose_plane16, transpose_plane16_with_alpha, transpose_rgb16, transpose_rgba16,
 };

--- a/src/transpose_arbitrary_group.rs
+++ b/src/transpose_arbitrary_group.rs
@@ -278,7 +278,7 @@ fn trs_arb_grouped<V: Copy, const N: usize, const FLOP: bool, const FLIP: bool>(
 /// returns: Result<(), TransposeError>
 ///
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn transpose_arbitrary_grouped<V: Copy, const N: usize>(
+pub fn transpose_arbitrary_grouped<V: Copy, const N: usize>(
     input: &[V],
     input_stride: usize,
     output: &mut [V],


### PR DESCRIPTION
## Summary

- Expose `transpose_arbitrary_grouped` in the public API by changing visibility from `pub(crate)` to `pub` and adding a `pub use` re-export in `lib.rs`.

## Motivation

Downstream crates that work with images having arbitrary channel counts (5+) currently cannot use this function because it is crate-private. The existing public API only covers common channel counts (1-4) via specialized functions like `transpose_rgb`, `transpose_rgba`, etc.

Making this generic function public allows users to transpose images with any channel count using the const generic parameter `N`, while the specialized functions remain available for optimal SIMD performance on common formats.

## Changes

- `src/transpose_arbitrary_group.rs`: `pub(crate) fn` → `pub fn`
- `src/lib.rs`: Added `pub use transpose_arbitrary_group::transpose_arbitrary_grouped;`